### PR TITLE
Reuse (<>) operator from semigroups

### DIFF
--- a/Text/PrettyPrint/Leijen/Text.hs
+++ b/Text/PrettyPrint/Leijen/Text.hs
@@ -119,14 +119,15 @@ module Text.PrettyPrint.Leijen.Text (
    ) where
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 710
-import Prelude hiding ((<$>))
+import           Prelude                hiding ((<$>))
 #endif
 
-import Data.String (IsString (..))
-import System.IO   (Handle, hPutChar, stdout)
+import           Data.String            (IsString (..))
+import           System.IO              (Handle, hPutChar, stdout)
 
 import           Data.Int               (Int64)
 import           Data.Monoid            (Monoid (..))
+import           Data.Semigroup         (Semigroup (..))
 import           Data.Text.Lazy         (Text)
 import qualified Data.Text.Lazy         as T
 import           Data.Text.Lazy.Builder (Builder)
@@ -135,7 +136,7 @@ import qualified Data.Text.Lazy.IO      as T
 
 
 infixr 5 </>,<//>,<$>,<$$>
-infixr 6 <>,<+>,<++>
+infixr 6 <+>,<++>
 
 
 -----------------------------------------------------------
@@ -323,12 +324,6 @@ vcat = fold (<$$>)
 fold      :: (Doc -> Doc -> Doc) -> [Doc] -> Doc
 fold _ [] = empty
 fold f ds = foldr1 f ds
-
--- | The document @(x \<\> y)@ concatenates document @x@ and document
---   @y@. It is an associative operation having 'empty' as a left and
---   right unit.  (infixr 6)
-(<>)   :: Doc -> Doc -> Doc
-x <> y = x `beside` y
 
 -- | The document @(x \<+\> y)@ concatenates document @x@ and @y@ with
 --   a 'space' in between.  (infixr 6)
@@ -776,6 +771,8 @@ instance IsString Doc where
 instance Monoid Doc where
     mempty  = empty
     mappend = beside
+
+instance Semigroup Doc
 
 -- | The data type @SimpleDoc@ represents rendered documents and is
 --   used by the display functions.

--- a/Text/PrettyPrint/Leijen/Text/Monadic.hs
+++ b/Text/PrettyPrint/Leijen/Text/Monadic.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, FlexibleInstances #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -21,7 +22,7 @@ module Text.PrettyPrint.Leijen.Text.Monadic (
    Doc, -- putDoc, hPutDoc,
 
    -- * Basic combinators
-   empty, char, text, (<>), nest, line, linebreak, group, softline,
+   empty, char, text, nest, line, linebreak, group, softline,
    softbreak, spacebreak,
 
    -- * Alignment
@@ -70,7 +71,7 @@ module Text.PrettyPrint.Leijen.Text.Monadic (
    ) where
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 710
-import Prelude hiding ((<$>))
+import           Prelude                      hiding ((<$>))
 #endif
 
 import           Text.PrettyPrint.Leijen.Text (Doc, Pretty (..), SimpleDoc (..),
@@ -79,12 +80,12 @@ import           Text.PrettyPrint.Leijen.Text (Doc, Pretty (..), SimpleDoc (..),
                                                renderOneLine, renderPretty)
 import qualified Text.PrettyPrint.Leijen.Text as PP
 
-import Control.Monad  (liftM, liftM2, liftM3, liftM4)
-import Data.String    (IsString (..))
-import Data.Text.Lazy (Text)
+import           Control.Monad                (liftM, liftM2, liftM3, liftM4)
+import           Data.String                  (IsString (..))
+import           Data.Text.Lazy               (Text)
 
 infixr 5 </>,<//>,<$>,<$$>
-infixr 6 <>,<+>,<++>
+infixr 6 <+>,<++>
 
 instance Monad m => IsString (m Doc) where
     fromString = string . fromString
@@ -249,12 +250,6 @@ hcat = liftM PP.hcat
 --   inserted by @vcat@, all documents are directly concatenated.
 vcat :: (Monad m) => m [Doc] -> m Doc
 vcat = liftM PP.vcat
-
--- | The document @(x \<\> y)@ concatenates document @x@ and document
---   @y@. It is an associative operation having 'empty' as a left and
---   right unit.  (infixr 6)
-(<>) :: (Monad m) => m Doc -> m Doc -> m Doc
-(<>) = liftM2 (PP.<>)
 
 -- | The document @(x \<+\> y)@ concatenates document @x@ and @y@ with
 --   a 'space' in between.  (infixr 6)

--- a/wl-pprint-text.cabal
+++ b/wl-pprint-text.cabal
@@ -19,4 +19,5 @@ Library
   Exposed-modules:     Text.PrettyPrint.Leijen.Text,
                        Text.PrettyPrint.Leijen.Text.Monadic
   Build-depends:       base < 5,
+                       semigroups,
                        text >= 0.11.0.0 && < 1.3.0.0


### PR DESCRIPTION
The `(<>)` operator from `wl-pprint-text` conflicts with the more generic one defined in `semigroups`.
Would you accept switching to the latter ?

The only downside is that we lose the monadic version of the operator, but I believe it's less of a pain than conflicting with the [widely used][1] `semigroups`.

Also, I've run stylish-haskell on the source, hence the additional little clean-up.

[1]: http://packdeps.haskellers.com/reverse/semigroups