### PR TITLE
Proposal/WIP: Add "Expanded" element to documents

### DIFF
--- a/Text/PrettyPrint/Leijen/Text.hs
+++ b/Text/PrettyPrint/Leijen/Text.hs
@@ -70,7 +70,7 @@ module Text.PrettyPrint.Leijen.Text (
    Doc,
 
    -- * Basic combinators
-   empty, char, text, textStrict, (<>), nest, line, linebreak, group, softline,
+   empty, char, text, textStrict, (<>), (<|>), nest, line, linebreak, group, softline,
    softbreak, spacebreak,
 
    -- * Alignment
@@ -870,8 +870,13 @@ nesting f = Nesting (f . fromIntegral)
 group   :: Doc -> Doc
 group x = Union (flatten x) x
 
-expanded :: Doc -> Doc -> Doc
-expanded = Expanded
+-- | The @<|>@ combinator is used to choose between expanded and
+--   compact representations. The document @l <|> r@ will format
+--   as the document @l@, however the document @group (l <|> r)@
+--   will format as @l@ only if the formatting for @r@ would be
+--   too long to fit on one line.
+(<|>) :: Doc -> Doc -> Doc
+(<|>) = Expanded
 
 flatten                :: Doc -> Doc
 flatten (Cat x y)      = Cat (flatten x) (flatten y)

--- a/Text/PrettyPrint/Leijen/Text.hs
+++ b/Text/PrettyPrint/Leijen/Text.hs
@@ -877,7 +877,7 @@ flatten                :: Doc -> Doc
 flatten (Cat x y)      = Cat (flatten x) (flatten y)
 flatten (Nest i x)     = Nest i (flatten x)
 flatten (Line brk)     = if brk then Empty else Text 1 (B.singleton ' ')
-flatten (Expanded _ r) = r
+flatten (Expanded _ r) = flatten r
 flatten (Union x _)    = flatten x
 flatten (Column f)     = Column (flatten . f)
 flatten (Nesting f)    = Nesting (flatten . f)


### PR DESCRIPTION
This pull request generalizes the notion of line breaks that turn into spaces, by introducing a new `Expanded` combinator.

`Expanded` is a combinator that combines two `Doc`s into one. The first `Doc` is the "expanded" form with line breaks, whereas the second form is a more compact variation. The process of flattening a `Doc` (as witnessed by `flatten`/`group`) now simply chooses the right branch of `Expanded`.

---

This pull request needs a little more tidying up, but I wanted to see if this proposal had any merit before persuing this further.