### PR TITLE
Text.Monadic:  disambiguate <> reference (GHC 8.4 compat)

### DIFF
--- a/Text/PrettyPrint/Leijen/Text/Monadic.hs
+++ b/Text/PrettyPrint/Leijen/Text/Monadic.hs
@@ -70,7 +70,7 @@ module Text.PrettyPrint.Leijen.Text.Monadic (
    ) where
 
 import Prelude ()
-import Prelude.Compat hiding ((<$>))
+import Prelude.Compat hiding ((<$>), (<>))
 
 
 import           Text.PrettyPrint.Leijen.Text (Doc, Pretty (..), SimpleDoc (..),


### PR DESCRIPTION
Tested on GHC 8.4.1-alpha1 and 8.0.2.