### PR TITLE
Allow base-compat-{0.13,0.14}

### DIFF
--- a/wl-pprint-text.cabal
+++ b/wl-pprint-text.cabal
@@ -36,7 +36,7 @@ Library
   Exposed-modules:     Text.PrettyPrint.Leijen.Text,
                        Text.PrettyPrint.Leijen.Text.Monadic
   Build-depends:       base        >= 4.5.0.0  && < 5,
-                       base-compat >= 0.10     && < 0.13,
+                       base-compat >= 0.10     && < 0.15,
                        text        >= 0.11.0.0 && < 2.1
   Default-language:    Haskell98
   GHC-Options:         -Wall


### PR DESCRIPTION
Closes #29, closes #32

Builds fine on at least 8.10.7, 9.2.7 and 9.6.1.