### PR TITLE
Allow text-2.1

### DIFF
--- a/wl-pprint-text.cabal
+++ b/wl-pprint-text.cabal
@@ -37,6 +37,6 @@ Library
                        Text.PrettyPrint.Leijen.Text.Monadic
   Build-depends:       base        >= 4.5.0.0  && < 5,
                        base-compat >= 0.10     && < 0.13,
-                       text        >= 0.11.0.0 && < 2.1
+                       text        >= 0.11.0.0 && < 2.2
   Default-language:    Haskell98
   GHC-Options:         -Wall


### PR DESCRIPTION
As a Hackage trustee, I made a matching revision: https://hackage.haskell.org/package/wl-pprint-text-1.2.0.2/revisions/