### PR TITLE
Remove noncanonical definitions.

### DIFF
--- a/Text/PrettyPrint/Leijen/Text.hs
+++ b/Text/PrettyPrint/Leijen/Text.hs
@@ -782,7 +782,9 @@ instance Semigroup Doc where
 #endif
 instance Monoid Doc where
     mempty  = empty
+#if !MIN_VERSION_base (4,9,0)
     mappend = beside
+#endif
 
 -- | The data type @SimpleDoc@ represents rendered documents and is
 --   used by the display functions.

--- a/Text/PrettyPrint/Leijen/Text.hs
+++ b/Text/PrettyPrint/Leijen/Text.hs
@@ -782,7 +782,7 @@ instance Semigroup Doc where
 #endif
 instance Monoid Doc where
     mempty  = empty
-#if !MIN_VERSION_base (4,9,0)
+#if !MIN_VERSION_base (4,11,0)
     mappend = beside
 #endif
 


### PR DESCRIPTION
This appeases the `-Wnoncanonical-monad-instances` warning. A future GHC release will treat noncanonical definitions as errors. See https://github.com/haskell/core-libraries-committee/issues/328.